### PR TITLE
Introduce support for running the test suite on more recent Ruby versions

### DIFF
--- a/buffered-logger.gemspec
+++ b/buffered-logger.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_development_dependency "mocha", "~> 0.13.3"
-  gem.add_development_dependency "rake", "~> 10.0.4"
+  gem.add_development_dependency "mocha", "~> 1.4.0"
+  gem.add_development_dependency "rake", "~> 12.3.1"
+  gem.add_development_dependency "minitest", "~> 5.11.3"
 end


### PR DESCRIPTION
Test output:

```
Lourenss-MacBook-Air:buffered-logger lourens$ bundle exec rake test
/opt/rubies/2.3.4/bin/ruby -w -I"lib:test" -I"/Users/lourens/.gem/ruby/2.3.4/gems/rake-12.3.1/lib" "/Users/lourens/.gem/ruby/2.3.4/gems/rake-12.3.1/lib/rake/rake_test_loader.rb" "test/buffered_logger/log_device_proxy_test.rb" "test/buffered_logger/middleware_test.rb" "test/buffered_logger_test.rb" 
Run options: --seed 16189

# Running:

............

Finished in 0.005601s, 2142.4746 runs/s, 2321.0141 assertions/s.

12 runs, 13 assertions, 0 failures, 0 errors, 0 skips
```

@kvs @baldowl 