### PR TITLE
BufferedLogger extend ActiveSupport Logger:

### DIFF
--- a/lib/buffered_logger.rb
+++ b/lib/buffered_logger.rb
@@ -2,7 +2,7 @@
 
 require 'logger'
 
-class BufferedLogger < ::Logger
+class BufferedLogger < defined?(::ActiveSupport::Logger) ? ::ActiveSupport::Logger : ::Logger
   require "buffered_logger/errors"
   require "buffered_logger/log_device_proxy"
   require "buffered_logger/middleware"

--- a/lib/buffered_logger/version.rb
+++ b/lib/buffered_logger/version.rb
@@ -2,6 +2,6 @@
 
 require "logger"
 
-class BufferedLogger < Logger
+class BufferedLogger < defined?(::ActiveSupport::Logger) ? ::ActiveSupport::Logger : ::Logger
   VERSION = "2.0.3"
 end

--- a/test/buffered_logger_test.rb
+++ b/test/buffered_logger_test.rb
@@ -27,5 +27,13 @@ describe BufferedLogger do
 
       assert_equal "foo\n", @buffer.string
     end
+
+    it 'silence the logs' do
+      @logger.silence(::Logger::ERROR) do
+        @logger.info('foo')
+      end
+
+      assert_empty @buffer.string
+    end
   end
 end


### PR DESCRIPTION
- Most of the time, the BufferedLogger will be used inside Rails
  application, the difference between the bare ruby Logger and
  ActiveSupport's logger is that you can silence the logger for the
  duration of a block.

  You can also broadcast log to multiple logger at once, which isn't
  impossible on the default ruby logger.
  All this features are implemented inside the ActiveSupport logger
  class.

  The app itself could create it's own logger to wrap BufferedLogger
  and add the feature from ActiveSupport's Logger but that requires
  some copy/pasta.

  I decided to choose to modify BufferedLogger as it made the most
  sense to me, it's also the same approach that heroku took a while
  ago on their heroku logger
  https://github.com/heroku/rails_stdout_logging/blob/master/lib/rails_stdout_logging/rails.rb